### PR TITLE
Add MCPo client docs and CLI entry

### DIFF
--- a/README-ko.md
+++ b/README-ko.md
@@ -178,6 +178,29 @@ docker run -i --rm \
   mcp/naver-search
 ```
 
+## MCPo 클라이언트로 실행
+
+1. MCPo 설치:
+   ```bash
+   pip install mcpo
+   ```
+2. 예시 구성 파일을 복사하고 환경 변수를 채웁니다:
+   ```bash
+   cp config.example.json config.json
+   # config.json 안의 NAVER_CLIENT_ID, NAVER_CLIENT_SECRET 값을 수정
+   ```
+3. 서버 빌드:
+   ```bash
+   npm install
+   npm run build
+   ```
+4. MCPo 실행:
+   ```bash
+   mcpo --config config.json
+   ```
+
+기본적으로 MCPo는 `http://localhost:8000`에서 실행되며 `/docs` 페이지에서 도구를 테스트할 수 있습니다.
+
 ## Claude Desktop 구성
 
 `claude_desktop_config.json`에 추가:

--- a/config.example.json
+++ b/config.example.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "naver-search": {
+      "command": "node",
+      "args": ["dist/src/index.js"],
+      "env": {
+        "NAVER_CLIENT_ID": "YOUR_NAVER_CLIENT_ID",
+        "NAVER_CLIENT_SECRET": "YOUR_NAVER_CLIENT_SECRET"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "@isnow890/naver-search-mcp",
   "version": "1.0.30",
   "description": "Naver Search MCP Server",
-  "main": "dist/index.js",
+  "main": "dist/src/index.js",
   "module": "./src/index.ts",
-  "types": "dist/index.d.ts",
+  "types": "dist/src/index.d.ts",
   "files": [
     "dist"
   ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";


### PR DESCRIPTION
## Summary
- ensure CLI binary works by adding Node shebang to server entry
- point package `main` and `types` to compiled paths
- document MCPo usage and provide example config

## Testing
- `npm run build`
- `timeout 5 mcpo --config config.json`

------
https://chatgpt.com/codex/tasks/task_e_689cae99a33083239a95b428707d900b